### PR TITLE
fix: 감정기록 데이터에 닉네임, 날짜, 요일 추가

### DIFF
--- a/src/main/java/backend/dto/EmotionRecordResponseDto.java
+++ b/src/main/java/backend/dto/EmotionRecordResponseDto.java
@@ -4,20 +4,29 @@ import backend.domain.Emotion;
 import backend.domain.EmotionRecord;
 import lombok.Getter;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 
 @Getter
 public class EmotionRecordResponseDto {
     private LocalDate day;     // 기록 날짜
     private Emotion emotion;   // 감정(8개 중 하나)
+    private String nickname; //유저 닉네임
+    private DayOfWeek dayOfWeek; //요일 정보
 
-    public EmotionRecordResponseDto(LocalDate day, Emotion emotion) {
+    public EmotionRecordResponseDto(LocalDate day, Emotion emotion, String nickname) {
         this.day = day;
         this.emotion = emotion;
+        this.nickname = nickname;
+        this.dayOfWeek = day.getDayOfWeek();
     }
 
     // Entity → DTO 변환 메서드
     public static EmotionRecordResponseDto of(EmotionRecord record) {
-        return new EmotionRecordResponseDto(record.getDay(), record.getEmotion());
+        return new EmotionRecordResponseDto(
+                record.getDay(),
+                record.getEmotion(),
+                record.getMember().getNickname() //멤버로부터 nickname 출력
+                );
     }
 }


### PR DESCRIPTION
<img width="859" alt="스크린샷 2025-06-06 오전 2 06 44" src="https://github.com/user-attachments/assets/d7a10785-8382-4d9a-9135-a66958e71c33" />
감정기록 시 닉네임, 요일 추가